### PR TITLE
⚙️ Allow defining ALLOWED_HOSTS in environment var

### DIFF
--- a/euphrosyne/settings.py
+++ b/euphrosyne/settings.py
@@ -30,7 +30,9 @@ SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(os.getenv("DJANGO_DEBUG", ""))
 
-ALLOWED_HOSTS = ["localhost", ".scalingo.io"] if not DEBUG else []
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "").split() or (
+    ["localhost", ".scalingo.io"] if not DEBUG else []
+)
 
 SITE_URL = os.environ["SITE_URL"]
 


### PR DESCRIPTION
This is useful whenever we want to make a remote environment DEBUG=true.