### PR TITLE
Customizes navbar : adds admin info, removes some links

### DIFF
--- a/euphrosyne/static/css/euphro_admin/base.css
+++ b/euphrosyne/static/css/euphro_admin/base.css
@@ -104,6 +104,10 @@ body {
   color: var(--black-euphro);
 }
 
+#user-tools #logout-link {
+  color: var(--delete-button-bg);
+}
+
 .module caption {
   background-color: white;
 }

--- a/euphrosyne/templates/admin/base.html
+++ b/euphrosyne/templates/admin/base.html
@@ -3,3 +3,12 @@
 {% block extrastyle %}
 <link rel="stylesheet" type="text/css" href="{% static "css/euphro_admin/base.css" %}">
 {% endblock %}
+
+{% block welcome-msg %}
+    <strong>{% firstof user.get_full_name user.get_username %}</strong>
+    {% if user.is_superuser or user.is_lab_admin %} (Admin) {% endif %} /
+{% endblock %}
+
+{% block userlinks %}
+    <a href="{% url 'admin:logout' %}" id="logout-link">{% translate 'Log out' %}</a>
+{% endblock %}

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-24 21:29+0100\n"
+"POT-Creation-Date: 2021-11-25 10:27+0100\n"
 "PO-Revision-Date: 2021-09-09 19:04+0200\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -114,6 +114,9 @@ msgstr "L'équipe Euphrosyne"
 
 msgid "Enter your information"
 msgstr "Entrez vos informations"
+
+msgid "Log out"
+msgstr "Déconnexion"
 
 msgid "Log in with ORCID"
 msgstr "Se connecter avec ORCID"


### PR DESCRIPTION
DRAFT : dépend de #45 pour l'attribut `is_lab_admin`

1. Ajout d'une indication si l'utilisateur est admin
2. Utilisation du nom complet plutôt que du prénom
3. Suppression des liens "View site" et "Change password"
4. Changement de couleur pour le bouton "Log out"

![image](https://user-images.githubusercontent.com/20670382/142473634-19d0a007-c034-449c-8c62-591e03f0f776.png)
