### PR TITLE
Feature/runs status front end

### DIFF
--- a/lab/admin/project.py
+++ b/lab/admin/project.py
@@ -21,7 +21,6 @@ from ..forms import (
 from ..models import BeamTimeRequest, Participation, Project, Run
 from ..permissions import is_lab_admin, is_project_leader
 from .mixins import LabPermission, LabPermissionMixin, LabRole
-from .run import BASE_RUN_FIELDSETS
 
 
 class ParticipationFormSet(BaseInlineFormSet):
@@ -101,12 +100,20 @@ class BeamTimeRequestInline(LabPermissionMixin, admin.StackedInline):
         return obj
 
 
-class RunInline(LabPermissionMixin, admin.StackedInline):
+class RunInline(LabPermissionMixin, admin.TabularInline):
     model = Run
     extra = 0
     show_change_link = True
     readonly_fields = RunDetailsForm.Meta.fields
-    fieldsets = BASE_RUN_FIELDSETS
+    fieldsets = (
+        (None, {"fields": ("start_date", "end_date")}),
+        (_("Embargo"), {"fields": ("embargo_date",)}),
+        (
+            _("Experimental conditions"),
+            {"fields": ("particle_type", "energy_in_keV", "beamline")},
+        ),
+        (_("Methods"), {"fields": ("methods",)}),
+    )
     template = "admin/edit_inline/stacked_run_in_project.html"
 
     lab_permissions = LabPermission(

--- a/lab/admin/run.py
+++ b/lab/admin/run.py
@@ -11,17 +11,6 @@ from ..models import Project, Run
 from ..permissions import LabRole, get_user_permission_group, is_lab_admin
 from .mixins import LabPermission, LabPermissionMixin
 
-BASE_RUN_FIELDSETS = (
-    (
-        None,
-        {"fields": ("label", "status", "start_date", "end_date", "embargo_date")},
-    ),
-    (
-        _("Experimental conditions"),
-        {"fields": ("particle_type", "energy_in_keV", "beamline")},
-    ),
-)
-
 
 @admin.register(Run)
 class RunAdmin(LabPermissionMixin, ModelAdmin):
@@ -29,7 +18,17 @@ class RunAdmin(LabPermissionMixin, ModelAdmin):
     form = RunDetailsForm
     list_display = ("project", "label", "start_date", "end_date")
     readonly_fields = ("status",)
-    fieldsets = ((_("Project"), {"fields": ("project",)}),) + BASE_RUN_FIELDSETS
+    fieldsets = (
+        (_("Project"), {"fields": ("project",)}),
+        (
+            None,
+            {"fields": ("label", "status", "start_date", "end_date", "embargo_date")},
+        ),
+        (
+            _("Experimental conditions"),
+            {"fields": ("particle_type", "energy_in_keV", "beamline")},
+        ),
+    )
 
     lab_permissions = LabPermission(
         add_permission=LabRole.ANY_STAFF_USER,

--- a/lab/forms.py
+++ b/lab/forms.py
@@ -146,6 +146,7 @@ class RunDetailsForm(ModelForm):
             "end_date",
             "embargo_date",
             "beamline",
+            "methods",
         )
         widgets = {
             "project": widgets.ProjectWidgetWrapper(

--- a/lab/templates/admin/edit_inline/stacked_run_in_project.html
+++ b/lab/templates/admin/edit_inline/stacked_run_in_project.html
@@ -21,7 +21,7 @@
   </h3>
   {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}
   {% for fieldset in inline_admin_form %}
-    {% include "admin/includes/fieldset.html" %}
+    {% include "admin/includes/run_inline_fieldset.html" %}
   {% endfor %}
   {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
   {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}

--- a/lab/templates/admin/includes/run_inline_fieldset.html
+++ b/lab/templates/admin/includes/run_inline_fieldset.html
@@ -1,0 +1,19 @@
+<fieldset class="module aligned {{ fieldset.classes }}">
+    {% if fieldset.name %}<h3>{{ fieldset.name }}</h3>{% endif %}
+    {% if fieldset.description %}
+        <div class="description">{{ fieldset.description|safe }}</div>
+    {% endif %}
+    <div style="display: flex">
+        {% for line in fieldset %}
+            <div class="form-row{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
+                {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
+                {% for field in line %}
+                    <div{% if not line.fields|length_is:'1' %} class="fieldBox{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %}"{% elif field.is_checkbox %} class="checkbox-row"{% endif %}>
+                        {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.errors }}{% endif %}
+                        <div class="readonly">{{ field.contents }}</div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% endfor %}
+    </div>
+</fieldset>

--- a/lab/tests/test_controlled_datalist.py
+++ b/lab/tests/test_controlled_datalist.py
@@ -27,6 +27,7 @@ def test_form_cleans_the_multiple_inputs_into_one():
     form = RunDetailsForm(
         data={
             "label": "I am mandatory",
+            "methods": {"me": "too"},
             "energy_in_keV_Proton": 1,
             "energy_in_keV_Alpha particle": 2,
             "energy_in_keV_Deuton": 3,
@@ -43,6 +44,7 @@ def test_form_allows_empty_value():
     form = RunDetailsForm(
         data={
             "label": "I am mandatory",
+            "methods": {"me": "too"},
             "energy_in_keV_Proton": 1,
             "energy_in_keV_Alpha particle": 2,
             "energy_in_keV_Deuton": "",
@@ -59,6 +61,7 @@ def test_form_stores_empty_controlled_value_if_controller_is_empty():
     form = RunDetailsForm(
         data={
             "label": "I am mandatory",
+            "methods": {"me": "too"},
             "energy_in_keV_Proton": 1,
             "energy_in_keV_Alpha particle": 2,
             "energy_in_keV_Deuton": 3,
@@ -74,6 +77,7 @@ def test_form_fails_gracefully_with_incoherent_controller_input():
     form = RunDetailsForm(
         data={
             "label": "I am mandatory",
+            "methods": {"me": "too"},
             "energy_in_keV_Proton": 1,
             "energy_in_keV_Alpha particle": 2,
             "energy_in_keV_Deuton": "",
@@ -88,6 +92,7 @@ def test_form_doesnt_raise_for_energy_when_other_errors():
     form = RunDetailsForm(
         data={
             "label": "I am mandatory",
+            "methods": {"me": "too"},
             "energy_in_keV_Proton": 1,
             "energy_in_keV_Alpha particle": 2,
             "energy_in_keV_Deuton": "",

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-01 12:01+0100\n"
+"POT-Creation-Date: 2021-12-01 12:06+0100\n"
 "PO-Revision-Date: 2021-09-09 19:04+0200\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -137,14 +137,22 @@ msgstr "Se connecter avec ORCID"
 msgid "Project member"
 msgstr "Membre du projet"
 
+#, fuzzy
+#| msgid "Embargo date"
+msgid "Embargo"
+msgstr "Date d'embargo"
+
+msgid "Experimental conditions"
+msgstr "Conditions expérimentales"
+
+msgid "Methods"
+msgstr "Méthodes"
+
 msgid "Leader"
 msgstr "Chef de projet"
 
 msgid "Basic information"
 msgstr "Information sessentielles"
-
-msgid "Experimental conditions"
-msgstr "Conditions expérimentales"
 
 #, fuzzy
 #| msgid "Projects"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ exclude = '''
 /(
   | migrations
   | venv
+  | .direnv
 )/
 
 '''


### PR DESCRIPTION
C'est vraiment une version ultra-simple, mais je me demande si ça vaut le coup de continuer sur ce chemin pour l'instant. En fait le mieux serait une totale réécriture du template du run inline. Mais j'ai quelques doutes sur le fait qu'il faille démarrer par là, et pas par exemple d'abord par le découpage du project admin en 3 parties (informations / runs / documents).

Dans l'état actuel, ça donne:

<img width="739" alt="image" src="https://user-images.githubusercontent.com/1884912/143326681-5e886446-6cb0-4e10-a536-1bcf5004db60.png">
