### PR TITLE
💚 Prevent form input loss by editing leader in popup

### DIFF
--- a/lab/static/js/admin/ViewObjectLookups.js
+++ b/lab/static/js/admin/ViewObjectLookups.js
@@ -1,0 +1,45 @@
+/*global SelectBox, interpolate*/
+// Inspired from django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+"use strict";
+{
+  const $ = django.jQuery;
+
+  function showAdminPopup(triggeringLink, name_regexp, add_popup) {
+    const name = triggeringLink.id.replace(name_regexp, "");
+    const href = new URL(triggeringLink.href);
+    if (add_popup) {
+      href.searchParams.set("_popup", 1);
+    }
+    const win = window.open(
+      href,
+      name,
+      "height=500,width=800,resizable=yes,scrollbars=yes"
+    );
+    win.focus();
+    return false;
+  }
+  function showRelatedObjectPopup(triggeringLink) {
+    return showAdminPopup(triggeringLink, /^(change|add|delete)_/, false);
+  }
+
+  function dismissViewObjectPopup(win, newRepr, newId) {
+    const id = win.name.replace(/^view_/, "");
+    const selectsSelector = interpolate("#%s, #%s_from, #%s_to", [id, id, id]);
+    $("#" + id).text(newRepr);
+    win.close();
+  }
+  window.dismissViewObjectPopup = dismissViewObjectPopup;
+
+  $(document).ready(function () {
+    $("body").on("click", ".popup-view-link", function (e) {
+      e.preventDefault();
+      if (this.href) {
+        const event = $.Event("django:show-related", { href: this.href });
+        $(this).trigger(event);
+        if (!event.isDefaultPrevented()) {
+          showRelatedObjectPopup(this);
+        }
+      }
+    });
+  });
+}

--- a/lab/static/js/admin/view_popup_response.js
+++ b/lab/static/js/admin/view_popup_response.js
@@ -1,0 +1,9 @@
+/*global opener */
+"use strict";
+{
+  const initData = JSON.parse(
+    document.getElementById("euphro-admin-popup-response-constants").dataset
+      .popupResponse
+  );
+  opener.dismissViewObjectPopup(window, initData.obj, initData.new_value);
+}

--- a/lab/templates/admin/change_leader.html
+++ b/lab/templates/admin/change_leader.html
@@ -20,6 +20,7 @@
 <div id="content-main">
     <form action="{% url 'admin:lab_project_leader_participation_change' project.id %}" method="post">
         {% csrf_token %}
+        {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
         <fieldset class="module aligned">
             <div class="form-row">
             {{ form }}

--- a/lab/templates/admin/view_popup_response.html
+++ b/lab/templates/admin/view_popup_response.html
@@ -1,0 +1,10 @@
+{% load i18n static %}<!DOCTYPE html>
+<html>
+  <head><title>{% translate 'Popup closing…' %}</title></head>
+  <body>
+    <script id="euphro-admin-popup-response-constants"
+            src="{% static "js/admin/view_popup_response.js" %}"
+            data-popup-response="{{ popup_response_data }}">
+    </script>
+  </body>
+</html>

--- a/lab/templates/widgets/leader_readonly.html
+++ b/lab/templates/widgets/leader_readonly.html
@@ -1,8 +1,9 @@
 {% load i18n static %}
-{% if user %} {{ user }} {% else %} {% translate 'No leader' %} {% endif %}
+<span id="id_leader">{% if user %} {{ user }} {% else %} {% translate 'No leader' %} {% endif %}</span>
 <a
-  class="change-related"
-  href="{% url 'admin:lab_project_leader_participation_change' project_id %}"
+  id="view_id_leader"
+  class="change-related popup-view-link"
+  href="{% url 'admin:lab_project_leader_participation_change' project_id %}?_popup=1"
   title="{% blocktranslate %}Change leader{% endblocktranslate %}"
   data-test="change-leader-link"
 >

--- a/lab/tests/factories.py
+++ b/lab/tests/factories.py
@@ -49,6 +49,21 @@ class ProjectWithLeaderFactory(ProjectFactory):
     )
 
 
+class ProjectWithMultipleParticipationsFactory(ProjectWithLeaderFactory):
+    member_1 = factory.RelatedFactory(
+        ParticipationFactory, factory_related_name="project", is_leader=False
+    )
+    member_2 = factory.RelatedFactory(
+        ParticipationFactory, factory_related_name="project", is_leader=False
+    )
+    member_3 = factory.RelatedFactory(
+        ParticipationFactory, factory_related_name="project", is_leader=False
+    )
+    member_4 = factory.RelatedFactory(
+        ParticipationFactory, factory_related_name="project", is_leader=False
+    )
+
+
 class RunFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Run

--- a/lab/tests/views/test_change_leader_view.py
+++ b/lab/tests/views/test_change_leader_view.py
@@ -1,52 +1,113 @@
+import json
+from unittest import mock
+
+import pytest
 from django.contrib.auth import get_user_model
-from django.test import TestCase
-from django.test.client import Client
+from django.core.exceptions import PermissionDenied
+from django.test.client import RequestFactory
 from django.urls import reverse
 
 from ...models import Project
+from ...views import change_leader_view
+from .. import factories
 
 
-class TestChangeLeaderView(TestCase):
-    def setUp(self):
-        self.admin_user = get_user_model().objects.create(
-            email="admin@test.test", is_staff=True, is_lab_admin=True
-        )
+@mock.patch.object(change_leader_view.ChangeLeaderView, "_process_request", mock.Mock())
+@mock.patch.object(change_leader_view, "is_lab_admin", mock.Mock(return_value=True))
+def test_change_leader_as_admin_is_allowed():
+    request = RequestFactory().post(
+        reverse("admin:lab_project_leader_participation_change", args=[1]),
+        data={"leader_participation": 42},
+    )
+    request.user = mock.Mock()
 
-        self.project = Project.objects.create(name="Test project")
+    # Should not raise PermissionDenied:
+    change_leader_view.ChangeLeaderView().dispatch(request, 1)
 
-        leader = get_user_model().objects.create(
-            email="leader@test.test", is_staff=True
-        )
-        self.project.participation_set.create(
-            user=leader,
-            is_leader=True,
-        )
 
-        member = get_user_model().objects.create(email="member@test.test")
-        self.member_participation = self.project.participation_set.create(
-            user=member,
-            is_leader=False,
-        )
+@mock.patch.object(change_leader_view, "is_lab_admin", mock.Mock(return_value=False))
+def test_change_leader_as_non_admin_is_forbidden():
+    request = RequestFactory().post(
+        reverse("admin:lab_project_leader_participation_change", args=[1]),
+        data={"leader_participation": 42},
+    )
+    request.user = mock.Mock()
 
-        self.client = Client()
-        self.client.force_login(self.admin_user)
+    with pytest.raises(PermissionDenied):
+        change_leader_view.ChangeLeaderView().dispatch(request, 1)
 
-    def test_change_leader_succeeds(self):
-        self.client.post(
-            reverse(
-                "admin:lab_project_leader_participation_change", args=[self.project.id]
-            ),
-            data={"leader_participation": self.member_participation.id},
-        )
-        self.project.refresh_from_db()
-        assert self.project.leader.id == self.member_participation.id
 
-    def test_change_leader_as_non_admin_is_forbidden(self):
-        self.client.force_login(self.project.leader.user)
-        response = self.client.post(
-            reverse(
-                "admin:lab_project_leader_participation_change", args=[self.project.id]
-            ),
-            data={"leader_participation": self.member_participation.id},
-        )
-        assert response.status_code == 403
+@pytest.mark.django_db
+def test_update_participation():
+    project = factories.ProjectWithMultipleParticipationsFactory()
+    old_leader = project.participation_set.filter(is_leader=True).get()
+    new_leader = project.participation_set.filter(is_leader=False)[0]
+    change_leader_view.ChangeLeaderView._update_participation(  # pylint: disable=protected-access
+        project, new_leader.id
+    )
+    new_leader.refresh_from_db()
+    old_leader.refresh_from_db()
+    assert new_leader.is_leader
+    assert not old_leader.is_leader
+
+
+@mock.patch.object(change_leader_view.transaction, "atomic", mock.MagicMock())
+@mock.patch.object(change_leader_view.Project, "leader", mock.Mock())
+@mock.patch.object(change_leader_view.ChangeLeaderForm, "full_clean", mock.Mock())
+@mock.patch.object(change_leader_view.ChangeLeaderView, "_update_participation")
+def test_change_leader_updates_participation(mocked_update_participation):
+    project = Project(id=1)
+    form = change_leader_view.ChangeLeaderView.form_class(
+        project=project, data={"leader_participation": 42}
+    )
+    form.cleaned_data = {"leader_participation": mock.Mock(id=42)}
+    view = change_leader_view.ChangeLeaderView()
+    view.project = project
+    view.request = RequestFactory().post(
+        reverse("admin:lab_project_leader_participation_change", args=[1]),
+        data={"leader_participation": 42},
+    )
+
+    view.form_valid(form)
+
+    mocked_update_participation.assert_called_with(project, 42)
+
+
+@mock.patch.object(change_leader_view.transaction, "atomic", mock.MagicMock())
+@mock.patch.object(change_leader_view.Project, "leader", mock.Mock())
+@mock.patch.object(change_leader_view.ChangeLeaderForm, "full_clean", mock.Mock())
+@mock.patch.object(change_leader_view.ChangeLeaderView, "_update_participation")
+@mock.patch.object(change_leader_view, "TemplateResponse")
+def test_change_leader_in_popup_renders_json_object(
+    template_response, mocked_update_participation
+):
+    project = Project(id=1)
+    form = change_leader_view.ChangeLeaderView.form_class(
+        project=project, data={"leader_participation": 42, "_popup": 1}
+    )
+    form.cleaned_data = {"leader_participation": mock.Mock(id=42)}
+    view = change_leader_view.ChangeLeaderView()
+    view.project = project
+    view.request = RequestFactory().post(
+        reverse("admin:lab_project_leader_participation_change", args=[1]),
+        data={"leader_participation": 42, "_popup": 1},
+    )
+    mocked_update_participation.return_value.get.return_value.user = get_user_model()(
+        id=1, first_name="Denis", last_name="Lamalice", email="d@m.com"
+    )
+
+    view.form_valid(form)
+
+    template_response.assert_called_with(
+        view.request,
+        "admin/view_popup_response.html",
+        {
+            "popup_response_data": json.dumps(
+                {
+                    "action": "change",
+                    "obj": "Lamalice, Denis<d@m.com>",
+                    "new_value": "1",
+                }
+            )
+        },
+    )

--- a/lab/views/change_leader_view.py
+++ b/lab/views/change_leader_view.py
@@ -1,10 +1,14 @@
-from typing import Any, Dict
+import json
+from typing import Any
 
 from django.contrib.admin import site
+from django.contrib.admin.options import IS_POPUP_VAR
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
+from django.db.models import QuerySet
 from django.http.request import HttpRequest
 from django.shortcuts import get_object_or_404
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.edit import FormView
@@ -13,7 +17,7 @@ from lab.permissions import is_lab_admin
 from shared.view_mixins import StaffUserRequiredMixin
 
 from ..forms import ChangeLeaderForm
-from ..models import Project
+from ..models import Participation, Project
 
 
 class ChangeLeaderView(StaffUserRequiredMixin, FormView):
@@ -26,17 +30,47 @@ class ChangeLeaderView(StaffUserRequiredMixin, FormView):
     def dispatch(self, request: HttpRequest, project_id: int, *args, **kwargs):
         if not is_lab_admin(request.user):
             raise PermissionDenied()
-        self.project = get_object_or_404(Project, pk=project_id)
-        return super().dispatch(request, *args, **kwargs)
+        return self._process_request(request, project_id, *args, **kwargs)
+
+    def _process_request(self, request, project_id, *args, **kwargs):
+        with transaction.atomic():
+            self.project = get_object_or_404(Project, pk=project_id)
+            return super().dispatch(request, *args, **kwargs)
+
+    @staticmethod
+    def _update_participation(
+        project: Project, leader_participation_id: int
+    ) -> QuerySet[Participation]:
+        project.participation_set.filter(is_leader=True).update(is_leader=False)
+        new_leader_participation_id = leader_participation_id
+        participation_qs = project.participation_set.filter(
+            id=new_leader_participation_id
+        )
+        participation_qs.update(is_leader=True)
+        return participation_qs
 
     def form_valid(self, form):
-        with transaction.atomic():
-            self.project.participation_set.filter(is_leader=True).update(
-                is_leader=False
+        leader_participation_id = form.cleaned_data["leader_participation"].id
+        participation_qs = self._update_participation(
+            self.project, leader_participation_id
+        )
+
+        if IS_POPUP_VAR in self.request.POST:
+            obj = participation_qs.get().user
+            value = obj.serializable_value(obj._meta.pk.attname)
+            popup_response_data = json.dumps(
+                {
+                    "action": "change",
+                    "obj": str(obj),
+                    "new_value": str(value),
+                }
             )
-            new_leader_participation = form.cleaned_data["leader_participation"].id
-            self.project.participation_set.filter(id=new_leader_participation).update(
-                is_leader=True
+            return TemplateResponse(
+                self.request,
+                "admin/view_popup_response.html",
+                {
+                    "popup_response_data": popup_response_data,
+                },
             )
 
         return super().form_valid(form)
@@ -44,13 +78,15 @@ class ChangeLeaderView(StaffUserRequiredMixin, FormView):
     def get_success_url(self) -> str:
         return reverse("admin:lab_project_change", args=[self.project.id])
 
-    def get_form_kwargs(self) -> Dict[str, Any]:
+    def get_form_kwargs(self) -> dict[str, Any]:
         return {**super().get_form_kwargs(), "project": self.project}
 
-    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         return {
             **super().get_context_data(**kwargs),
             **site.each_context(self.request),
             "subtitle": "{} | {}".format(self.project.name, _("Change leader")),
             "project": self.project,
+            "is_popup": IS_POPUP_VAR in self.request.GET,
+            "is_popup_var": IS_POPUP_VAR,
         }

--- a/lab/widgets.py
+++ b/lab/widgets.py
@@ -5,10 +5,17 @@ from django import forms
 from django.contrib.admin import site
 from django.contrib.admin.widgets import AdminSplitDateTime, RelatedFieldWidgetWrapper
 from django.db.models.fields.reverse_related import ForeignObjectRel
-from django.forms.renderers import get_default_renderer
-from django.forms.widgets import ChoiceWidget, HiddenInput, Input, Select, Textarea
+from django.forms.widgets import (
+    ChoiceWidget,
+    HiddenInput,
+    Input,
+    Select,
+    Textarea,
+    Widget,
+)
 from django.urls import reverse
-from django.utils.safestring import mark_safe
+
+from euphro_auth.models import User
 
 
 class UserWidgetWrapper(RelatedFieldWidgetWrapper):
@@ -60,12 +67,24 @@ class InstitutionWidgetWrapper(RelatedFieldWidgetWrapper):
         )
 
 
-class LeaderReadonlyWidget:
+class LeaderReadonlyWidget(Widget):
     template_name = "widgets/leader_readonly.html"
 
-    def render(self, context, renderer=None):
-        renderer = get_default_renderer()
-        return mark_safe(renderer.render(self.template_name, context))
+    class Media:
+        js = ("js/admin/ViewObjectLookups.js",)
+
+    def __init__(self, project_id: int, user: User = None, attrs=None):
+        self.user = user
+        self.project_id = project_id
+        super().__init__(attrs)
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        return {
+            **context,
+            "user": self.user,
+            "project_id": self.project_id,
+        }
 
 
 class DisabledSelectWithHidden(Select):

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -452,6 +452,9 @@ msgstr "Taille"
 msgid "No document yet"
 msgstr "Aucun document ajouté"
 
+msgid "Popup closing…"
+msgstr "Popup en cours de fermeture…"
+
 msgid "Other"
 msgstr "Autre"
 


### PR DESCRIPTION
Voici une tentative d'utiliser le même système de popups que Django admin pour gérer la view edit leader, qui est en soi assez générique.

Reste à faire la même chose pour les add run (dans une autre PR).

@wiwski Je te laisse me dire ce que tu en penses avant de poursuivre avec les Run.