### PR TITLE
fix: Fix Django Admin dark mode

### DIFF
--- a/euphrosyne/templates/admin/base.html
+++ b/euphrosyne/templates/admin/base.html
@@ -5,6 +5,7 @@
 <title>{% block title %}{% endblock %}</title>
 <link rel="stylesheet" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
 <link rel="stylesheet" type="text/css" href="{% static "main.css"%}"></link>
+<link rel="stylesheet" href="{% block dark-mode-vars %}{% static "admin/css/dark_mode.css" %}{% endblock %}">
 {% if not is_popup and is_nav_sidebar_enabled %}
   <link rel="stylesheet" href="{% static "admin/css/nav_sidebar.css" %}">
   <script src="{% static 'admin/js/nav_sidebar.js' %}" defer></script>


### PR DESCRIPTION
Was due to an upgrade of Djanog to 4.1+ where the dark mode has been moved to a specific file