### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ on:
     types: [opened, reopened, synchronize, edited]
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   DJANGO_SECRET_KEY: n0t5os3cre7-${{ github.sha }}
   EMAIL_HOST: localhost


### PR DESCRIPTION
Potential fix for [https://github.com/betagouv/euphrosyne/security/code-scanning/3](https://github.com/betagouv/euphrosyne/security/code-scanning/3)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. Because none of the jobs appear to need to write to the repository or PRs, a safe minimal setting is `contents: read`. This can be added at the top level of the workflow so it applies to all jobs, which avoids duplicating configuration and does not change existing functionality given how the jobs are used.

The single best way to fix this file is to insert a workflow‑level `permissions:` block right after the `on:` section, before the `env:` block. This will apply to `python-checks`, `python-tests`, and `frontend-tests` uniformly. Concretely, in `.github/workflows/test.yaml`, between line 5 (`workflow_call:`) and line 7 (`env:`), add:

```yaml
permissions:
  contents: read
```

No imports, methods, or definitions are needed beyond this YAML addition; it is purely declarative configuration within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
